### PR TITLE
SC-12764 Fix travis CI build to use Ubuntu 22 & JDK17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ language: go
 go:
   - "1.10"
 
+dist: jammy
+
+env:
+  - JAVA_HOME=/usr/local/lib/jvm/openjdk17
+
 addons:
   sonarcloud:
     organization: "sonarcloud"
     token:
       secure: "NsV4wkCqio4gwtrNZaWVnNKYpndn2HzCkROlYG97NoQHBRKAUx4W7WzfnrtltGbBZKq53I4Zk+6aVZyXIv/HMWA6MgI5UMdnDOB2pgaz/Mbry+E1iYvtwYjIFlOB942XE9AOHpnXcJ3TlKOVc9CMwXOVmcVC6vj950TRa5yLuMI0xiKWW/e/iSIJcDXnXmciKFoPD9fDIQLzTJw7NZsgflQ9hggz/HrjVQUFZnz4Dmm45YLNgDt0bI1ulK2Q23ql3mvA4sbn0JmQNzmxBLCyz9MFClj+i9XfSXNJFMwdiDb+7e51MrLnwCxQsd1iJqVC/z2hzsHmWpfK6L+S10l78d6B2DJ2k9VciBfNa8YOU0rD7rKz+0/YaNB0zkNJRPOzuFR2/txpquRXrJOJTi5s63CMF1bePPBJjUX085cgcVj6SrZ7s+UlpKk8W5xEUivZcmINMee6cveLWs81CRf+Kntb97xlDdiDJI9amamUQgH/JBAUlu3Ta3jXByGMzO0sdjAwtp95q/68Z8a3JgwGesBfVZPt3YYhHgEeUZlppKNWWxX6p+/7nXUaLh1Oc3o++5sWQ1RrdZqEseRUrkxfIQxOekWd2nvpQMcmKEbmvLiE8Eaj3M95WUceucK4NJC3aq3DhIIjMswd6rTXF3qlcjjBkMLYc4+2+p63O7RK8FA="
-      
+
 install:
   # Installs Go Meta Linter (Golint and Go vet are also supported independently)
   - go get -u gopkg.in/alecthomas/gometalinter.v2
@@ -25,7 +30,7 @@ script:
 
 cache:
   directories:
-    - '$HOME/.sonar/cache'
+    - "$HOME/.sonar/cache"
 
 # Don't copy the following part if you're using this project as a starting point of yours
 notifications:


### PR DESCRIPTION
The build is currently broken because java 11 is used to scan this project.

This PR bumps the distribution used in CI from `xenial` to `jammy` (which includes JDK17, and switches java version to it).